### PR TITLE
Add postgresql to be abble to use heroku pg:*

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV HOME /root
 ENV DEBIAN_FRONTEND noninteractivetoken
 
 RUN apt-get update && \
-    apt-get install -y sudo curl openssh-client ruby git
+    apt-get install -y sudo curl openssh-client ruby git postgresql
 
 RUN curl https://toolbelt.heroku.com/install.sh | sh
 ENV PATH $PATH:/usr/local/heroku/bin


### PR DESCRIPTION
I have to add postgresql to be abble to use the pg:psql (and other pg:\* heroku-cli commands).

Perhaps there is an other way to do this ?
